### PR TITLE
Verifying that leading tone is part of a dominant chord.

### DIFF
--- a/voicing.py
+++ b/voicing.py
@@ -277,10 +277,10 @@ def main():
         "time_signature", type=str, nargs="?", help="the time signature"
     )
     parser.set_defaults(
-        key="A",
-        chord_progression="viio/II ii ii7 vii65/II ii6 v V/II ii",
-        durations="1 1 1 1/2 1/2 1 1",
-        time_signature="4/4",
+        key="B-",
+        chord_progression="I I6 IV V43/ii ii V V7 I",
+        durations="1 1/2 1 1/2 1 1/2 1/2 1",
+        time_signature="6/8",
     )
     args = parser.parse_args()
     key_and_chords = f"{args.key}: {args.chord_progression}"

--- a/voicing.py
+++ b/voicing.py
@@ -134,10 +134,15 @@ def progressionCost(key, chord1, chord2):
     # V->I means ti->do or ti->sol
     pitches = key.getPitches()
     pitches[6] = key.getLeadingTone()
-    if chord1.root().name in (
-        pitches[4].name,
-        pitches[6].name,
-    ) and chord2.root().name in (pitches[0].name, pitches[5].name):
+    if (
+        chord1.root().name
+        in (
+            pitches[4].name,
+            pitches[6].name,
+        )
+        and chord2.root().name in (pitches[0].name, pitches[5].name)
+        and pitches[6].name in chord1.pitchNames
+    ):
         voice = chord1.pitchNames.index(pitches[6].name)
         delta = chord2.pitches[voice].midi - chord1.pitches[voice].midi
         if not (delta == 1 or (delta == -4 and voice >= 1 and voice <= 2)):
@@ -251,7 +256,10 @@ def main():
         "voice-leading procedures and dynamic programming."
     )
     parser.add_argument(
-        "key", type=str, nargs="?", help="the key of the chord progression",
+        "key",
+        type=str,
+        nargs="?",
+        help="the key of the chord progression",
     )
     parser.add_argument(
         "chord_progression",
@@ -269,10 +277,10 @@ def main():
         "time_signature", type=str, nargs="?", help="the time signature"
     )
     parser.set_defaults(
-        key="B-",
-        chord_progression="I I6 IV V43/ii ii V V7 I",
-        durations="1 1/2 1 1/2 1 1/2 1/2 1",
-        time_signature="6/8",
+        key="A",
+        chord_progression="viio/II ii ii7 vii65/II ii6 v V/II ii",
+        durations="1 1 1 1/2 1/2 1 1",
+        time_signature="4/4",
     )
     args = parser.parse_args()
     key_and_chords = f"{args.key}: {args.chord_progression}"


### PR DESCRIPTION
This is a fix for `voicing.progressionCost`.

In the following example, the function generates an exception:

```python
parser.set_defaults(
        key="A",
        chord_progression="viio/II ii ii7 vii65/II ii6 v V/II ii",
        durations="1 1 1 1/2 1/2 1 1",
        time_signature="4/4",
    )
```

The reason, is that it assumes that a chord that has the fifth degree as the root, will always have the leading tone.

This is not true, as exemplified by this progression, which is taken from an excerpt of a Bach chorale.

It is a common practice to have a minor fifth degree `v`, especially in the context of a tonicization/modulation.

The PR adds an additional check on the last portion of `progressionCost` (last line is the only change in the PR):
```python
if (
        chord1.root().name
        in (
            pitches[4].name,
            pitches[6].name,
        )
        and chord2.root().name in (pitches[0].name, pitches[5].name)
        and pitches[6].name in chord1.pitchNames
```

When there is no leading tone, it should be safe to ignore the penalization applied by this portion of the code.

Additional changes appear in the PR, but these are just formatting suggestions applied by `black`.


