### PR TITLE
Adding key signatures to generated chorales

### DIFF
--- a/voicing.py
+++ b/voicing.py
@@ -193,7 +193,7 @@ def voiceProgression(key, chordProgression):
     return list(reversed(ret)), totalCost
 
 
-def generateScore(chords, lengths=None, ts="4/4"):
+def generateScore(chords, lengths=None, ts="4/4", key='C'):
     """Generates a four-part score from a sequence of chords.
 
     Soprano and alto parts are displayed on the top (treble) clef, while tenor
@@ -215,8 +215,8 @@ def generateScore(chords, lengths=None, ts="4/4"):
         voices[2].append(tenor)
         voices[3].append(bass)
 
-    female = Part([TrebleClef(), TimeSignature(ts), voices[0], voices[1]])
-    male = Part([BassClef(), TimeSignature(ts), voices[2], voices[3]])
+    female = Part([TrebleClef(), TimeSignature(ts), Key(key), voices[0], voices[1]])
+    male = Part([BassClef(), TimeSignature(ts), Key(key), voices[2], voices[3]])
     score = Score([female, male])
     return score
 
@@ -241,7 +241,7 @@ def generateChorale(chorale, lengths=None, ts="4/4"):
     for key, chords in lines:
         phrase, _ = voiceProgression(key, chords)
         progression.extend(phrase)
-    score = generateScore(progression, lengths, ts)
+    score = generateScore(progression, lengths, ts, key)
     return score
 
 


### PR DESCRIPTION
This PR adds key signatures to the generated chorales.

Currently, the generated score shows the accidentals in every note, and has a key signature of `C` / `a`:

![image](https://user-images.githubusercontent.com/7258463/93001803-a036b880-f4ff-11ea-8183-d94034c8949f.png)

It'd be better to output the key signature that corresponds to the key of the chorale:

![image](https://user-images.githubusercontent.com/7258463/93001848-fad01480-f4ff-11ea-9343-319f2ea31891.png)

Some artifacts are still happening with the accidentals. For example, the first `B-` shouldn't be printed. I am afraid that has to do with how `music21` processes the score. Yet, I still think it would be good to add this change here, and maybe submit an issue in `music21` related to the artifacts in accidentals. Maybe there is a more idiomatic way of encoding the chorales in `music21` that works better with their routines for generating the score. 
