### PR TITLE
RomanText

### DIFF
--- a/example.rntxt
+++ b/example.rntxt
@@ -1,0 +1,7 @@
+Composer: Eric Zhang
+Title: Example progression
+
+Time signature: 6/8 
+
+m1 b1 Bb: I b1.66 I6 b2 IV b2.66 V43/ii
+m2 b1 ii b1.67 V b2 V7 b2.33 I

--- a/voicing.py
+++ b/voicing.py
@@ -260,21 +260,21 @@ def main():
         "input",
         type=str,
         nargs="?",
-        default='example.rntxt',
+        default="example.rntxt",
         help="A RomanText input file with the chord progression",
     )
     args = parser.parse_args()
-    s = parse(args.input, format='rntxt')
-    key_it = s.flat.getElementsByClass('Key')
-    key = next(key_it, Key('C')).tonicPitchNameWithCase
-    ts_it = s.flat.getElementsByClass('TimeSignature')
-    ts = next(ts_it, TimeSignature('4/4')).ratioString
+    s = parse(args.input, format="rntxt")
+    key_it = s.flat.getElementsByClass("Key")
+    key = next(key_it, Key("C")).tonicPitchNameWithCase
+    ts_it = s.flat.getElementsByClass("TimeSignature")
+    ts = next(ts_it, TimeSignature("4/4")).ratioString
     durations = []
     chords = []
-    for rn in s.flat.getElementsByClass('RomanNumeral'):
+    for rn in s.flat.getElementsByClass("RomanNumeral"):
         durations.append(rn.duration.quarterLength)
         chords.append(rn.figure)
-    chord_progression = ' '.join(chords)
+    chord_progression = " ".join(chords)
     key_and_chords = f"{key}: {chord_progression}"
     generateChorale(key_and_chords, durations, ts).show()
 

--- a/voicing.py
+++ b/voicing.py
@@ -264,7 +264,7 @@ def main():
         help="A RomanText input file with the chord progression",
     )
     args = parser.parse_args()
-    s = parse(args.input, format="rntxt")
+    s = parse(args.input, format="rntext")
     key_it = s.flat.getElementsByClass("Key")
     key = next(key_it, Key("C")).tonicPitchNameWithCase
     ts_it = s.flat.getElementsByClass("TimeSignature")

--- a/voicing.py
+++ b/voicing.py
@@ -3,6 +3,7 @@ import argparse
 import itertools
 from fractions import Fraction
 
+from music21.converter import parse
 from music21.note import Note
 from music21.pitch import Pitch
 from music21.chord import Chord
@@ -256,37 +257,26 @@ def main():
         "voice-leading procedures and dynamic programming."
     )
     parser.add_argument(
-        "key",
+        "input",
         type=str,
         nargs="?",
-        help="the key of the chord progression",
-    )
-    parser.add_argument(
-        "chord_progression",
-        type=str,
-        nargs="?",
-        help='a sequence of roman numeral annotations, e.g., "I I6 IV V43/ii ii V V7 I"',
-    )
-    parser.add_argument(
-        "durations",
-        type=str,
-        nargs="?",
-        help="the associated durations of the chords (in quarter notes)",
-    )
-    parser.add_argument(
-        "time_signature", type=str, nargs="?", help="the time signature"
-    )
-    parser.set_defaults(
-        key="B-",
-        chord_progression="I I6 IV V43/ii ii V V7 I",
-        durations="1 1/2 1 1/2 1 1/2 1/2 1",
-        time_signature="6/8",
+        default='example.rntxt',
+        help="A RomanText input file with the chord progression",
     )
     args = parser.parse_args()
-    key_and_chords = f"{args.key}: {args.chord_progression}"
-    durations = [Fraction(x) for x in args.durations.split()]
-    time_signature = args.time_signature
-    generateChorale(key_and_chords, durations, time_signature).show()
+    s = parse(args.input, format='rntxt')
+    key_it = s.flat.getElementsByClass('Key')
+    key = next(key_it, Key('C')).tonicPitchNameWithCase
+    ts_it = s.flat.getElementsByClass('TimeSignature')
+    ts = next(ts_it, TimeSignature('4/4')).ratioString
+    durations = []
+    chords = []
+    for rn in s.flat.getElementsByClass('RomanNumeral'):
+        durations.append(rn.duration.quarterLength)
+        chords.append(rn.figure)
+    chord_progression = ' '.join(chords)
+    key_and_chords = f"{key}: {chord_progression}"
+    generateChorale(key_and_chords, durations, ts).show()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Recently, I have realized that pickup measures are difficult to handle in the current input representation for this algorithm. Then, I thought that the RomanText notation, which is already included with music21, can help mitigating this problem in the long run.

The [RomanText](https://zenodo.org/record/3527756#.X6Nst65yaV4) is a notation introduced in 2019 for dealing with Roman Numeral Analysis.

It is currently integrated with music21 and it allows to parse a file like this:
```
Composer: Eric Zhang
Title: Example progression

Time signature: 6/8 

m1 b1 Bb: I b1.66 I6 b2 IV b2.66 V43/ii
m2 b1 ii b1.67 V b2 V7 b2.33 I
```
into a music21 stream like this:
```python
In [1]: import music21
In [2]: s = music21.converter.parse('example.rntxt')
In [3]: s.show('text')

{0.0} <music21.metadata.Metadata object at 0x7f5df0f1b2b0>
{0.0} <music21.stream.Part 0x7f5e165bff70>
    {0.0} <music21.stream.Measure 1 offset=0.0>
        {0.0} <music21.key.Key of B- major>
        {0.0} <music21.meter.TimeSignature 6/8>
        {0.0} <music21.roman.RomanNumeral I in B- major>
        {1.0} <music21.roman.RomanNumeral I6 in B- major>
        {1.5} <music21.roman.RomanNumeral IV in B- major>
        {2.5} <music21.roman.RomanNumeral V43/ii in B- major>
    {3.0} <music21.stream.Measure 2 offset=3.0>
        {0.0} <music21.roman.RomanNumeral ii in B- major>
        {1.0} <music21.roman.RomanNumeral V in B- major>
        {1.5} <music21.roman.RomanNumeral V7 in B- major>
        {2.0} <music21.roman.RomanNumeral I in B- major>
```
and a score like this one:
```python
In [4]: s.show()
```
![image](https://user-images.githubusercontent.com/7258463/98193408-201f4480-1eeb-11eb-9c76-e2cdd19babc8.png)

More specifically, it can provide a mechanism to enter
- Key (and key changes)
- Time Signature (and time signature changes)
- Durations
- Roman Numerals

Which are the same parameters used for this project. The advantage is that a stream parsed from a RomanText file provides other parameters, such as pickup measures and time offsets for each `RomanNumeral` object.

The file format is well documented, it is super easy to parse using music21, and it ensures that certain things work without extra effort (e.g., `len(durations) == len(chord_progression)`). Also, there is a good collection of [scores in this format](https://github.com/MarkGotham/When-in-Rome/tree/master/Corpus), which would be immediately available to try out with this algorithm. 

This PR just adds a superficial compatibility at the entry point. If you get on board with the idea, I can suggest some ways to make it work in a nicer way (but requiring more changes).