### PR TITLE
Adding penalization to identical contiguous voicing

### DIFF
--- a/voicing.py
+++ b/voicing.py
@@ -101,6 +101,10 @@ def progressionCost(key, chord1, chord2):
     ):
         cost += 40
 
+    # Penalize the same chord
+    if chord1.notes == chord2.notes:
+        cost += 2
+
     # Avoid big jumps
     diff = [abs(chord1.pitches[i].midi - chord2.pitches[i].midi) for i in range(4)]
     cost += (diff[3] // 3) ** 2 if diff[3] else 1


### PR DESCRIPTION
Dealing with #9.

Slight penalization on repeated voicings (`cost = 2`).

Tested with this example (a slight variation of the original example, 3 repeated harmonies):
```python
parser.set_defaults(
        key="B-",
        chord_progression="I I IV IV ii V V I",
        durations="1 1/2 1 1/2 1 1/2 1/2 1",
        time_signature="6/8",
)
```

Without penalization:
![image](https://user-images.githubusercontent.com/7258463/99722520-c38d5f00-2a7e-11eb-8bc5-9f8dfdcf98ca.png)

With penalization:
![image](https://user-images.githubusercontent.com/7258463/99722746-19fa9d80-2a7f-11eb-94f6-92c9b6dccf8b.png)

Notice that the third repeated pair, `V` and `V`, was voiced identically (not **always** changing the voicing, which may be desired), but the first two changed.

Second version sounds much better in my opinion.

